### PR TITLE
[FEAT] 로그인 및 회원가입 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "study-room-fe",
       "version": "0.0.0",
       "dependencies": {
+        "@types/node": "^22.5.4",
+        "path": "^0.12.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.53.0",
         "react-icons": "^5.3.0",
         "react-router-dom": "^6.26.2",
         "styled-components": "^6.1.13",
@@ -18,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@types/node": "^22.5.4",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^8.5.0",
@@ -1099,6 +1103,15 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.5.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.4.tgz",
+      "integrity": "sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.12",
@@ -2340,6 +2353,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2621,6 +2640,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2721,6 +2750,15 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2775,6 +2813,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.53.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.0.tgz",
+      "integrity": "sha512-M1n3HhqCww6S2hxLxciEXy2oISPnAzxY7gvwVPrtlczTM/1dDadXgUxDpHMrMTblDOcm/AXtXxHwZ3jpg1mqKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-icons": {
@@ -3237,6 +3291,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@types/node": "^22.5.4",
+    "path": "^0.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.0",
     "react-icons": "^5.3.0",
     "react-router-dom": "^6.26.2",
     "styled-components": "^6.1.13",
@@ -20,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@types/node": "^22.5.4",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^8.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,16 @@ import { ThemeProvider } from 'styled-components';
 import GlobalStyles from './styles/GlobalStyles';
 import { theme } from './styles/theme';
 import Router from './router/Router';
+import Layout from './components/layout/Layout';
 
 function App() {
   return (
     <BrowserRouter>
       <ThemeProvider theme={theme}>
         <GlobalStyles />
-        <Router />
+        <Layout>
+          <Router />
+        </Layout>
       </ThemeProvider>
     </BrowserRouter>
   );

--- a/src/components/button/Button.style.ts
+++ b/src/components/button/Button.style.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+const sizeStyles = {
+  small: {
+    padding: '6px 12px',
+    fontSize: '12px',
+  },
+  medium: {
+    padding: '8px 16px',
+    fontSize: '14px',
+  },
+  large: {
+    padding: '12px 24px',
+    fontSize: '18px',
+  },
+};
+
+export const StyledButton = styled.button<{
+  size: 'small' | 'medium' | 'large';
+}>`
+  background-color: #599bfc;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 20px;
+  padding: ${({ size }) => sizeStyles[size].padding};
+  font-size: ${({ size }) => sizeStyles[size].fontSize};
+
+  &:hover {
+    background-color: #8bbaff;
+  }
+`;

--- a/src/components/button/Button.style.ts
+++ b/src/components/button/Button.style.ts
@@ -18,7 +18,7 @@ const sizeStyles = {
 export const StyledButton = styled.button<{
   size: 'small' | 'medium' | 'large';
 }>`
-  background-color: #599bfc;
+  background-color: ${({ theme }) => theme.color.mainStrong};
   color: white;
   border: none;
   border-radius: 8px;
@@ -28,6 +28,6 @@ export const StyledButton = styled.button<{
   font-size: ${({ size }) => sizeStyles[size].fontSize};
 
   &:hover {
-    background-color: #8bbaff;
+    background-color: ${({ theme }) => theme.color.btnOk};
   }
 `;

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,17 @@
+import { forwardRef, ComponentPropsWithRef } from 'react';
+
+import { StyledButton } from './Button.style';
+
+interface ButtonProps extends ComponentPropsWithRef<'button'> {
+  size?: 'small' | 'medium' | 'large';
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ size = 'medium', ...props }, ref) => (
+    <StyledButton ref={ref} size={size} {...props}>
+      {props.children}
+    </StyledButton>
+  )
+);
+
+export default Button;

--- a/src/components/input/Input.style.ts
+++ b/src/components/input/Input.style.ts
@@ -7,12 +7,16 @@ export const StyledInput = styled.input.withConfig({
   height: 60px;
   padding: 16px;
   border-radius: 8px;
-  border: 1px solid ${({ hasError }) => (hasError ? '#ff7777' : '#ddd')};
+  border: 1px solid
+    ${({ hasError, theme }) =>
+      hasError ? theme.color.btnWarn : theme.color.bgGray};
+
   font-size: 16px;
   box-sizing: border-box;
 
   &:focus {
     outline: none;
-    border-color: ${({ hasError }) => (hasError ? '#ff7777' : '#599bfc')};
+    border-color: ${({ hasError, theme }) =>
+      hasError ? theme.color.btnWarn : theme.color.mainStrong};
   }
 `;

--- a/src/components/input/Input.style.ts
+++ b/src/components/input/Input.style.ts
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+export const StyledInput = styled.input.withConfig({
+  shouldForwardProp: (prop) => prop !== 'hasError',
+})<{ hasError?: boolean }>`
+  width: 100%;
+  height: 60px;
+  padding: 16px;
+  border-radius: 8px;
+  border: 1px solid ${({ hasError }) => (hasError ? '#ff7777' : '#ddd')};
+  font-size: 16px;
+  box-sizing: border-box;
+
+  &:focus {
+    outline: none;
+    border-color: ${({ hasError }) => (hasError ? '#ff7777' : '#599bfc')};
+  }
+`;

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,0 +1,16 @@
+import { forwardRef, ComponentPropsWithRef } from 'react';
+import { StyledInput } from './Input.style';
+
+interface InputProps extends ComponentPropsWithRef<'input'> {
+  hasError?: boolean;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ hasError, ...props }, ref) => (
+    <StyledInput ref={ref} hasError={hasError} {...props}>
+      {props.children}
+    </StyledInput>
+  )
+);
+
+export default Input;

--- a/src/components/layout/Layout.style.ts
+++ b/src/components/layout/Layout.style.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const RouterStyle = styled.div`
+export const LayoutStyle = styled.div`
   display: flex;
 `;
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+
+import { useLocation } from 'react-router-dom';
+import { MainContentArea, LayoutStyle } from './Layout.style';
+import Header from '../header/Header';
+import Sidebar from '../sidebar/Sidebar';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps) {
+  const location = useLocation();
+
+  const isAuthPage =
+    location.pathname === '/login' || location.pathname === '/register';
+
+  return (
+    <LayoutStyle>
+      {!isAuthPage && <Sidebar />}
+      <MainContentArea>
+        {!isAuthPage && <Header />}
+        {children}
+      </MainContentArea>
+    </LayoutStyle>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import App from './App.tsx';
+import App from './App';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,0 +1,72 @@
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/button/Button';
+import Input from '@/components/input/Input';
+import {
+  Container,
+  ErrorMessage,
+  Form,
+  InputContainer,
+  LinkContainer,
+  StyledLink,
+  Span,
+  Title,
+} from '@/styles/AuthFormStyles';
+
+interface LoginFormInputs {
+  userId: string;
+  password: string;
+}
+
+export default function LoginPage() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LoginFormInputs>();
+  const navigate = useNavigate();
+
+  const onSubmit: SubmitHandler<LoginFormInputs> = (data) => {
+    navigate('/');
+    console.log(data);
+  };
+
+  return (
+    <Container>
+      <Title>로그인</Title>
+      <Form onSubmit={handleSubmit(onSubmit)}>
+        <InputContainer>
+          <Input
+            hasError={!!errors.userId}
+            placeholder="아이디"
+            {...register('userId', {
+              required: '아이디를 입력해주세요.',
+            })}
+          />
+          {errors.userId && (
+            <ErrorMessage>{errors.userId.message}</ErrorMessage>
+          )}
+        </InputContainer>
+        <InputContainer>
+          <Input
+            hasError={!!errors.password}
+            placeholder="비밀번호"
+            {...register('password', {
+              required: '비밀번호를 입력해주세요.',
+            })}
+          />
+          {errors.password && (
+            <ErrorMessage>{errors.password.message}</ErrorMessage>
+          )}
+        </InputContainer>
+        <Button type="submit" size="large">
+          로그인
+        </Button>
+      </Form>
+      <LinkContainer>
+        <Span>아직 회원이 아니신가요?</Span>
+        <StyledLink to={'/register'}>회원가입</StyledLink>
+      </LinkContainer>
+    </Container>
+  );
+}

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -26,9 +26,8 @@ export default function LoginPage() {
   } = useForm<LoginFormInputs>();
   const navigate = useNavigate();
 
-  const onSubmit: SubmitHandler<LoginFormInputs> = (data) => {
+  const onSubmit: SubmitHandler<LoginFormInputs> = () => {
     navigate('/');
-    console.log(data);
   };
 
   return (

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -14,7 +14,7 @@ import {
   Title,
 } from '@/styles/AuthFormStyles';
 
-interface LoginFormInputs {
+interface RegisterFormInputs {
   userId: string;
   nickname: string;
   password: string;
@@ -27,11 +27,11 @@ export default function RegisterPage() {
     handleSubmit,
     watch,
     formState: { errors },
-  } = useForm<LoginFormInputs>();
+  } = useForm<RegisterFormInputs>();
   const navigate = useNavigate();
   const password = watch('password');
 
-  const onSubmit: SubmitHandler<LoginFormInputs> = () => {
+  const onSubmit: SubmitHandler<RegisterFormInputs> = () => {
     navigate('/login');
   };
 

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -1,0 +1,125 @@
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import Button from '@/components/button/Button';
+import Input from '@/components/input/Input';
+import {
+  Container,
+  ErrorMessage,
+  Form,
+  InputContainer,
+  Label,
+  LinkContainer,
+  StyledLink,
+  Span,
+  Title,
+} from '@/styles/AuthFormStyles';
+
+interface LoginFormInputs {
+  userId: string;
+  nickname: string;
+  password: string;
+  confirmPassword: string;
+}
+
+export default function RegisterPage() {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<LoginFormInputs>();
+  const navigate = useNavigate();
+  const password = watch('password');
+
+  const onSubmit: SubmitHandler<LoginFormInputs> = (data) => {
+    navigate('/');
+    console.log(data);
+  };
+
+  return (
+    <Container>
+      <Title>회원가입</Title>
+      <Form onSubmit={handleSubmit(onSubmit)}>
+        <InputContainer>
+          <Label>아이디</Label>
+          <Input
+            hasError={!!errors.userId}
+            placeholder="아이디"
+            {...register('userId', {
+              required: '아이디를 입력해주세요.',
+              pattern: {
+                value: /^[a-zA-Z0-9]{6,16}$/,
+                message: '아이디는 영어와 숫자로 구성된 6~16글자여야 합니다.',
+              },
+            })}
+          />
+          {errors.userId && (
+            <ErrorMessage>{errors.userId.message}</ErrorMessage>
+          )}
+        </InputContainer>
+        <InputContainer>
+          <Label>닉네임</Label>
+          <Input
+            hasError={!!errors.nickname}
+            placeholder="닉네임"
+            {...register('nickname', {
+              required: '닉네임을 입력해주세요.',
+              pattern: {
+                value: /^[a-zA-Z가-힣0-9]{2,8}$/,
+                message:
+                  '닉네임은 영어, 한글, 숫자로 구성된 2~8글자여야 합니다.',
+              },
+            })}
+          />
+          {errors.nickname && (
+            <ErrorMessage>{errors.nickname.message}</ErrorMessage>
+          )}
+        </InputContainer>
+        <InputContainer>
+          <Label>비밀번호</Label>
+          <Input
+            hasError={!!errors.password}
+            type="password"
+            placeholder="비밀번호"
+            {...register('password', {
+              required: '비밀번호를 입력해주세요.',
+              pattern: {
+                value:
+                  /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+=-]).{6,16}$/,
+                message:
+                  '비밀번호는 영어, 숫자, 특수문자를 포함한 6~16글자여야 합니다.',
+              },
+            })}
+          />
+          {errors.password && (
+            <ErrorMessage>{errors.password.message}</ErrorMessage>
+          )}
+        </InputContainer>
+        <InputContainer>
+          <Label>비밀번호 확인</Label>
+          <Input
+            hasError={!!errors.confirmPassword}
+            type="password"
+            placeholder="비밀번호 확인"
+            {...register('confirmPassword', {
+              required: '비밀번호 확인을 입력해주세요.',
+              validate: (value) =>
+                value === password || '비밀번호가 일치하지 않습니다.',
+            })}
+          />
+          {errors.confirmPassword && (
+            <ErrorMessage>{errors.confirmPassword.message}</ErrorMessage>
+          )}
+        </InputContainer>
+
+        <Button type="submit" size="large">
+          회원가입
+        </Button>
+      </Form>
+      <LinkContainer>
+        <Span>이미 회원이신가요?</Span>
+        <StyledLink to={'/login'}>로그인</StyledLink>
+      </LinkContainer>
+    </Container>
+  );
+}

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -31,9 +31,8 @@ export default function RegisterPage() {
   const navigate = useNavigate();
   const password = watch('password');
 
-  const onSubmit: SubmitHandler<LoginFormInputs> = (data) => {
+  const onSubmit: SubmitHandler<LoginFormInputs> = () => {
     navigate('/login');
-    console.log(data);
   };
 
   return (

--- a/src/pages/register/RegisterPage.tsx
+++ b/src/pages/register/RegisterPage.tsx
@@ -32,7 +32,7 @@ export default function RegisterPage() {
   const password = watch('password');
 
   const onSubmit: SubmitHandler<LoginFormInputs> = (data) => {
-    navigate('/');
+    navigate('/login');
     console.log(data);
   };
 
@@ -111,7 +111,6 @@ export default function RegisterPage() {
             <ErrorMessage>{errors.confirmPassword.message}</ErrorMessage>
           )}
         </InputContainer>
-
         <Button type="submit" size="large">
           회원가입
         </Button>

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,26 +1,12 @@
-import { Route, Routes, useLocation } from 'react-router-dom';
-import Header from '../components/header/Header';
-import Sidebar from '../components/sidebar/Sidebar';
-import { MainContentArea, RouterStyle } from './Router.style';
+import { Route, Routes } from 'react-router-dom';
 import LoginPage from '../pages/login/LoginPage';
 import RegisterPage from '../pages/register/RegisterPage';
 
 export default function Router() {
-  const location = useLocation();
-
-  const isAuthPage =
-    location.pathname === '/login' || location.pathname === '/register';
-
   return (
-    <RouterStyle>
-      {!isAuthPage && <Sidebar />}
-      <MainContentArea>
-        {!isAuthPage && <Header />}
-        <Routes>
-          <Route path="/login" element={<LoginPage />}></Route>
-          <Route path="/register" element={<RegisterPage />}></Route>
-        </Routes>
-      </MainContentArea>
-    </RouterStyle>
+    <Routes>
+      <Route path="/login" element={<LoginPage />}></Route>
+      <Route path="/register" element={<RegisterPage />}></Route>
+    </Routes>
   );
 }

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -1,14 +1,25 @@
+import { Route, Routes, useLocation } from 'react-router-dom';
 import Header from '../components/header/Header';
 import Sidebar from '../components/sidebar/Sidebar';
 import { MainContentArea, RouterStyle } from './Router.style';
+import LoginPage from '../pages/login/LoginPage';
+import RegisterPage from '../pages/register/RegisterPage';
 
 export default function Router() {
+  const location = useLocation();
+
+  const isAuthPage =
+    location.pathname === '/login' || location.pathname === '/register';
+
   return (
     <RouterStyle>
-      <Sidebar />
+      {!isAuthPage && <Sidebar />}
       <MainContentArea>
-        <Header />
-        <div>컨텐츠 영역</div>
+        {!isAuthPage && <Header />}
+        <Routes>
+          <Route path="/login" element={<LoginPage />}></Route>
+          <Route path="/register" element={<RegisterPage />}></Route>
+        </Routes>
       </MainContentArea>
     </RouterStyle>
   );

--- a/src/styles/AuthFormStyles.ts
+++ b/src/styles/AuthFormStyles.ts
@@ -1,0 +1,63 @@
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+export const Container = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  margin: auto;
+`;
+
+export const Title = styled.h1`
+  font-size: 28px;
+  margin-bottom: 30px;
+  font-weight: 600;
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 480px;
+`;
+
+export const InputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  margin-bottom: 24px;
+`;
+
+export const ErrorMessage = styled.span`
+  color: #ff7777;
+  font-size: 12px;
+  margin-top: 10px;
+`;
+
+export const LinkContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  color: #434343;
+  text-decoration: none;
+  margin-top: 20px;
+`;
+
+export const StyledLink = styled(Link)`
+  color: #599bfc;
+  font-weight: 600;
+  text-decoration: none;
+`;
+
+export const Span = styled.span`
+  font-size: 16px;
+  color: #666;
+`;
+
+export const Label = styled.label`
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  color: #666;
+`;

--- a/src/styles/AuthFormStyles.ts
+++ b/src/styles/AuthFormStyles.ts
@@ -30,7 +30,7 @@ export const InputContainer = styled.div`
 `;
 
 export const ErrorMessage = styled.span`
-  color: #ff7777;
+  color: ${({ theme }) => theme.color.btnWarn};
   font-size: 12px;
   margin-top: 10px;
 `;
@@ -39,25 +39,25 @@ export const LinkContainer = styled.div`
   display: flex;
   gap: 8px;
   align-items: center;
-  color: #434343;
+  color: ${({ theme }) => theme.color.lineGray};
   text-decoration: none;
   margin-top: 20px;
 `;
 
 export const StyledLink = styled(Link)`
-  color: #599bfc;
+  color: ${({ theme }) => theme.color.mainStrong};
   font-weight: 600;
   text-decoration: none;
 `;
 
 export const Span = styled.span`
   font-size: 16px;
-  color: #666;
+  color: ${({ theme }) => theme.color.bgDarkGray};
 `;
 
 export const Label = styled.label`
   font-size: 16px;
   font-weight: 600;
   margin-bottom: 8px;
-  color: #666;
+  color: ${({ theme }) => theme.color.bgDarkGray};
 `;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -6,6 +6,7 @@ export interface Colors {
   lineGray: string;
   btnOk: string;
   btnWarn: string;
+  bgDarkGray: string;
   bgGray: string;
   bgLightGray: string;
   bgYellowNote: string;
@@ -16,8 +17,9 @@ export const theme: DefaultTheme = {
     main: '#DDEBFD',
     mainStrong: '#599BFC',
     lineGray: '#A1A1A1',
-    btnOk: '#509CFF',
+    btnOk: '#6FA9FF',
     btnWarn: '#FF7777',
+    bgDarkGray: '#616161',
     bgGray: '#E5E5E5',
     bgLightGray: '#F9F9F9',
     bgYellowNote: '#FFF9EE',


### PR DESCRIPTION
## ✅ 작업 내용

- Button, Input 컴포넌트 구현
- 로그인, 회원가입 페이지 구현
- `react hook form` 사용하여 유효성 검사(비밀번호도 규칙 추가였습니다.) 

<img width="559" alt="스크린샷 2024-09-14 오후 3 51 55" src="https://github.com/user-attachments/assets/47cae978-2219-4afa-a79d-42efc9c6e84c">

<img width="603" alt="스크린샷 2024-09-14 오후 3 52 51" src="https://github.com/user-attachments/assets/8a0571f0-03ee-4b91-b5d7-22b59ddf2c65">


디자인은 다른 홈페이지들 디자인 참고하여 아래와 같이 조금 수정했습니다.
- 아이콘들은 없는 게 나을 것 같아서 우선 다 제외했습니다. 
- 중복검사 버튼은 따로 버튼을 눌러서 확인하는 방식이 아니라 유효성 검사처럼 작성할 때 바로 보여주는 게 나을 것 같아 제외하였습니다.
- 회원가입 시 프로필 사진을 받는 곳은 없는 것 같아 원래 디자인 대로 구현하였습니다.

## ✅ 리뷰 요청사항
- `styled components` 사용한 지 오래 되어서... 맞게 사용했는지 확인 부탁드립니다.
- 파일 구조나 코드 개선 사항이 보인다면 말씀해주세요!

## 📢 관련 이슈
- close #7 