### PR TITLE
[REFACTOR] 공부방 페이지 UI 및 헤더 수정

### DIFF
--- a/src/components/button/SCreateButton.style.ts
+++ b/src/components/button/SCreateButton.style.ts
@@ -1,14 +1,18 @@
-import { ButtonSize } from '@/styles/theme';
 import styled from 'styled-components';
 
 export const SCreateButtonStyle = styled.button.withConfig({
   shouldForwardProp: (prop) => !['borderRadius'].includes(prop),
-})<{ size: ButtonSize; borderRadius?: string; fontSize?: string }>`
+})<{
+  width?: string;
+  height?: string;
+  borderRadius?: string;
+  fontSize?: string;
+}>`
   color: white;
   border: none;
   background-color: ${({ theme }) => theme.color.mainStrong};
-  width: ${({ theme, size }) => theme.studyRoomButton[size].width};
-  height: ${({ theme, size }) => theme.studyRoomButton[size].height};
+  width: ${({ width }) => width || 'auto'};
+  height: ${({ height }) => height || 'auto'};
   border-radius: ${({ theme, borderRadius }) =>
     borderRadius || theme.borderRadius};
   font-size: ${({ fontSize }) => fontSize || '16px'};

--- a/src/components/button/SCreateButton.tsx
+++ b/src/components/button/SCreateButton.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { IconType } from 'react-icons';
-import { ButtonSize } from '@/styles/theme';
 import * as S from './SCreateButton.style';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   label: string;
   Icon?: IconType;
-  size?: ButtonSize;
+  width?: string;
+  height?: string;
   borderRadius?: string;
   fontSize?: string;
   iconSize?: string;
@@ -14,7 +14,8 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 
 function SCreateButton({
   label,
-  size = 'small',
+  width,
+  height,
   Icon,
   borderRadius,
   fontSize = '24px',
@@ -23,7 +24,8 @@ function SCreateButton({
 }: ButtonProps) {
   return (
     <S.SCreateButtonStyle
-      size={size}
+      width={width}
+      height={height}
       borderRadius={borderRadius}
       fontSize={fontSize}
       {...props}

--- a/src/components/header/Header.style.ts
+++ b/src/components/header/Header.style.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const HeaderContainer = styled.header<{ isStudyRoomPage?: boolean }>`
   background-color: white;
   width: 100%;
+  height: 80px;
   flex-shrink: 0;
   border-bottom: 1px solid ${({ theme }) => theme.color.bgGray};
   display: flex;

--- a/src/components/header/Header.style.ts
+++ b/src/components/header/Header.style.ts
@@ -1,9 +1,8 @@
 import styled from 'styled-components';
 
-export const HeaderContainer = styled.header`
+export const HeaderContainer = styled.header<{ isStudyRoomPage?: boolean }>`
   background-color: white;
   width: 100%;
-  height: 80px;
   flex-shrink: 0;
   border-bottom: 1px solid ${({ theme }) => theme.color.bgGray};
   display: flex;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,18 +3,26 @@ import * as S from './Header.style';
 
 interface HeaderProps {
   title: string;
+  showAuthButtons?: boolean;
+  isStudyRoomPage?: boolean;
 }
 
-export default function Header({ title }: HeaderProps) {
+export default function Header({
+  title,
+  showAuthButtons,
+  isStudyRoomPage,
+}: HeaderProps) {
   const navigate = useNavigate();
 
   return (
     <S.HeaderContainer>
-      <S.HeaderTitle>{title}</S.HeaderTitle>
-      <S.ButtonWrapper>
-        <S.Button onClick={() => navigate('/login')}>로그인</S.Button>
-        <S.Button onClick={() => navigate('/register')}>회원가입</S.Button>
-      </S.ButtonWrapper>
+      <S.HeaderTitle>{title}</S.HeaderTitle>{' '}
+      {isStudyRoomPage && showAuthButtons && (
+        <S.ButtonWrapper>
+          <S.Button onClick={() => navigate('/login')}>로그인</S.Button>
+          <S.Button onClick={() => navigate('/register')}>회원가입</S.Button>
+        </S.ButtonWrapper>
+      )}
     </S.HeaderContainer>
   );
 }

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,26 +3,18 @@ import * as S from './Header.style';
 
 interface HeaderProps {
   title: string;
-  showAuthButtons?: boolean;
-  isStudyRoomPage?: boolean;
 }
 
-export default function Header({
-  title,
-  showAuthButtons,
-  isStudyRoomPage,
-}: HeaderProps) {
+export default function Header({ title }: HeaderProps) {
   const navigate = useNavigate();
 
   return (
     <S.HeaderContainer>
       <S.HeaderTitle>{title}</S.HeaderTitle>{' '}
-      {isStudyRoomPage && showAuthButtons && (
-        <S.ButtonWrapper>
-          <S.Button onClick={() => navigate('/login')}>로그인</S.Button>
-          <S.Button onClick={() => navigate('/register')}>회원가입</S.Button>
-        </S.ButtonWrapper>
-      )}
+      <S.ButtonWrapper>
+        <S.Button onClick={() => navigate('/login')}>로그인</S.Button>
+        <S.Button onClick={() => navigate('/register')}>회원가입</S.Button>
+      </S.ButtonWrapper>
     </S.HeaderContainer>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom';
 import { MainContentArea, LayoutStyle } from './Layout.style';
 import Header from '../header/Header';
 import Sidebar from '../sidebar/Sidebar';
-import RSidebar from '../rsidebar/RSidebar';
+//import RSidebar from '../rsidebar/RSidebar';
 
 interface LayoutProps {
   children: ReactNode;
@@ -32,7 +32,7 @@ export default function Layout({ children }: LayoutProps) {
       <MainContentArea>
         {!authPagePath && !studyRoomPagePath && <Sidebar />}
         {children}
-        {studyRoomPagePath && <RSidebar />}
+        {/* {studyRoomPagePath && <RSidebar />} */}
       </MainContentArea>
     </LayoutStyle>
   );

--- a/src/components/rsidebar/RSidebar.style.ts
+++ b/src/components/rsidebar/RSidebar.style.ts
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 
 export const RSidebarStyle = styled.div`
-  min-width: 600px;
+  display: flex;
+  min-width: 350px;
   height: 100vh;
   background: ${({ theme }) => theme.color.main};
-  display: flex;
   justify-content: center;
 `;
 
@@ -13,19 +13,19 @@ export const Wrapper = styled.div`
   flex-direction: column;
   justify-content: space-evenly;
   align-items: center;
-  height: 100%;
+  height: auto;
 `;
 
 export const CurrentTime = styled.div`
   color: #7c7c7c; // plannerTimeGray
-  font-size: 36px;
+  font-size: 28px;
   font-weight: 600;
 `;
 
 export const ContentWrapper = styled.div`
-  width: 494px;
-  height: 750px;
-  border-radius: 15px;
+  width: 287px;
+  height: 600px;
+  border-radius: 10px;
   background-color: white;
   margin: 8px 0px;
 `;
@@ -40,13 +40,13 @@ export const TabsWrapper = styled.div`
 export const Tab = styled.div.withConfig({
   shouldForwardProp: (prop) => !['isSelected'].includes(prop),
 })<{ isSelected?: boolean }>`
-  font-size: 36px;
+  font-size: 20px;
 
   color: ${(props) => (props.isSelected ? 'black' : '#7c7c7c')};
   text-align: center;
-  width: 120px;
+  width: auto;
   border-radius: 8px;
-  padding: 10px;
+  padding: 10px 0;
 
   &:hover {
     cursor: pointer;

--- a/src/components/rsidebar/todos/Todos.style.ts
+++ b/src/components/rsidebar/todos/Todos.style.ts
@@ -12,8 +12,9 @@ export const Wrapper = styled.div`
 
 export const DateWrapper = styled.div`
   display: flex;
-  font-size: 40px;
+  font-size: 27px;
   justify-content: space-around;
+  align-items: center;
   font-weight: 600;
   width: 100%;
   margin-top: 20px;
@@ -139,14 +140,13 @@ export const ErrorText = styled.span`
 export const AddButton = styled.button`
   display: flex;
   align-items: center;
-  width: 439px;
-  height: 77px;
+  width: 256px;
+  height: 52px;
   border: none;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.color.mainStrong};
   color: white;
-  font-size: 40px;
-  font-weight: 600;
+  font-size: 25px;
   margin-bottom: 20px;
   padding: 0px 20px;
 

--- a/src/components/studyProfileBox/StudyProfileBox.style.ts
+++ b/src/components/studyProfileBox/StudyProfileBox.style.ts
@@ -6,10 +6,24 @@ export const StudyProfileBoxStyle = styled.div<{ $isGroup: boolean }>`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  border-radius: 20px;
-  width: ${({ $isGroup }) => ($isGroup ? '384px' : '1088px')};
-  height: ${({ $isGroup }) => ($isGroup ? '242px' : '686px')};
+  border-radius: ${({ $isGroup }) => ($isGroup ? '5px' : '15px')};
+  width: ${({ $isGroup }) => ($isGroup ? '265px' : '752px')};
+  height: ${({ $isGroup }) => ($isGroup ? '166px' : '476px')};
   background-color: ${({ theme }) => theme.color.bgGray};
+`;
+
+export const ContentDisplay = styled.div<{ $isGroup: boolean }>`
+  position: absolute;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  font-size: ${({ $isGroup }) => ($isGroup ? '10px' : '20px')};
+  top: ${({ $isGroup }) => ($isGroup ? '10px' : '30px')};
+  color: #868686;
+
+  .content {
+    margin: ${({ $isGroup }) => ($isGroup ? '0 10px' : '0 35px')};
+  }
 `;
 
 export const TimeDisplay = styled.div<{ $isGroup: boolean }>`
@@ -17,11 +31,13 @@ export const TimeDisplay = styled.div<{ $isGroup: boolean }>`
   display: flex;
   justify-content: space-between;
   width: 100%;
-  font-size: ${({ $isGroup }) => ($isGroup ? '30px' : '70px')};
-  top: 20px;
+  font-size: ${({ $isGroup }) => ($isGroup ? '20px' : '50px')};
+  top: ${({ $isGroup }) => ($isGroup ? '25px' : '60px')};
+  font-weight: 600;
+  color: #434343;
 
   .time {
-    margin: ${({ $isGroup }) => ($isGroup ? '0 20px' : '0px 40px')};
+    margin: ${({ $isGroup }) => ($isGroup ? '0 10px' : '0px 35px')};
   }
 `;
 
@@ -29,8 +45,8 @@ export const ProfileImageContainer = styled.div<{ $isGroup: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: ${({ $isGroup }) => ($isGroup ? '182px' : '622px')};
-  height: ${({ $isGroup }) => ($isGroup ? '182px' : '622px')};
+  width: ${({ $isGroup }) => ($isGroup ? '112px' : '428px')};
+  height: ${({ $isGroup }) => ($isGroup ? '112px' : '428px')};
   border-radius: 50%;
   background-color: white;
 `;
@@ -43,7 +59,7 @@ export const ProfileImage = styled.img`
 
 export const UserIdDisplay = styled.div<{ $isGroup: boolean }>`
   position: absolute;
-  font-size: ${({ $isGroup }) => ($isGroup ? '22px' : '50px')};
-  left: ${({ $isGroup }) => ($isGroup ? '20px' : '40px')};
-  bottom: ${({ $isGroup }) => ($isGroup ? '20px' : '40px')};
+  font-size: ${({ $isGroup }) => ($isGroup ? '12px' : '50px')};
+  left: ${({ $isGroup }) => ($isGroup ? '10px' : '40px')};
+  bottom: ${({ $isGroup }) => ($isGroup ? '10px' : '40px')};
 `;

--- a/src/components/studyProfileBox/StudyProfileBox.style.ts
+++ b/src/components/studyProfileBox/StudyProfileBox.style.ts
@@ -15,7 +15,8 @@ export const StudyProfileBoxStyle = styled.div<{ $isGroup: boolean }>`
 export const ContentDisplay = styled.div<{ $isGroup: boolean }>`
   position: absolute;
   display: flex;
-  justify-content: space-between;
+  justify-content: ${({ $isGroup }) =>
+    $isGroup ? 'flex-end' : 'space-between'};
   width: 100%;
   font-size: ${({ $isGroup }) => ($isGroup ? '10px' : '20px')};
   top: ${({ $isGroup }) => ($isGroup ? '10px' : '30px')};
@@ -29,7 +30,8 @@ export const ContentDisplay = styled.div<{ $isGroup: boolean }>`
 export const TimeDisplay = styled.div<{ $isGroup: boolean }>`
   position: absolute;
   display: flex;
-  justify-content: space-between;
+  justify-content: ${({ $isGroup }) =>
+    $isGroup ? 'flex-end' : 'space-between'};
   width: 100%;
   font-size: ${({ $isGroup }) => ($isGroup ? '20px' : '50px')};
   top: ${({ $isGroup }) => ($isGroup ? '25px' : '60px')};

--- a/src/components/studyProfileBox/StudyProfileBox.tsx
+++ b/src/components/studyProfileBox/StudyProfileBox.tsx
@@ -7,6 +7,8 @@ interface StudyProfileBoxProps {
   initialCurrentTaskTime?: string;
   initialTotalStudyTime?: string;
   profileImage?: string;
+  profileImageWidth?: string;
+  profileImageHeight?: string;
 }
 
 const StudyProfileBox: React.FC<StudyProfileBoxProps> = ({
@@ -15,6 +17,8 @@ const StudyProfileBox: React.FC<StudyProfileBoxProps> = ({
   initialCurrentTaskTime = '00:00:00',
   initialTotalStudyTime = '00:00:00',
   profileImage = '',
+  profileImageWidth = '',
+  profileImageHeight = '',
 }) => {
   return (
     <S.StudyProfileBoxStyle $isGroup={isGroup}>
@@ -26,7 +30,11 @@ const StudyProfileBox: React.FC<StudyProfileBoxProps> = ({
         {!isGroup && <div className="time">{initialCurrentTaskTime}</div>}
         <div className="time">{initialTotalStudyTime}</div>
       </S.TimeDisplay>
-      <ProfileImageBox src={profileImage} width="400px" height="400px" />
+      <ProfileImageBox
+        src={profileImage}
+        width={profileImageWidth}
+        height={profileImageHeight}
+      />
       {isGroup && userId && (
         <S.UserIdDisplay $isGroup={isGroup}>{userId}</S.UserIdDisplay>
       )}

--- a/src/components/studyProfileBox/StudyProfileBox.tsx
+++ b/src/components/studyProfileBox/StudyProfileBox.tsx
@@ -19,14 +19,14 @@ const StudyProfileBox: React.FC<StudyProfileBoxProps> = ({
   return (
     <S.StudyProfileBoxStyle $isGroup={isGroup}>
       <S.ContentDisplay $isGroup={isGroup}>
-        <div className="content">선택된 할 일 공부 시간</div>
+        {!isGroup && <div className="content">선택된 할 일 공부 시간</div>}
         <div className="content">전체 공부 시간</div>
       </S.ContentDisplay>
       <S.TimeDisplay $isGroup={isGroup}>
-        <div className="time">{initialCurrentTaskTime}</div>
+        {!isGroup && <div className="time">{initialCurrentTaskTime}</div>}
         <div className="time">{initialTotalStudyTime}</div>
       </S.TimeDisplay>
-      <ProfileImageBox src={profileImage} width="428px" height="428px" />
+      <ProfileImageBox src={profileImage} width="400px" height="400px" />
       {isGroup && userId && (
         <S.UserIdDisplay $isGroup={isGroup}>{userId}</S.UserIdDisplay>
       )}

--- a/src/components/studyProfileBox/StudyProfileBox.tsx
+++ b/src/components/studyProfileBox/StudyProfileBox.tsx
@@ -18,11 +18,15 @@ const StudyProfileBox: React.FC<StudyProfileBoxProps> = ({
 }) => {
   return (
     <S.StudyProfileBoxStyle $isGroup={isGroup}>
+      <S.ContentDisplay $isGroup={isGroup}>
+        <div className="content">선택된 할 일 공부 시간</div>
+        <div className="content">전체 공부 시간</div>
+      </S.ContentDisplay>
       <S.TimeDisplay $isGroup={isGroup}>
         <div className="time">{initialCurrentTaskTime}</div>
         <div className="time">{initialTotalStudyTime}</div>
       </S.TimeDisplay>
-      <ProfileImageBox src={profileImage} width="622px" height="622px" />
+      <ProfileImageBox src={profileImage} width="428px" height="428px" />
       {isGroup && userId && (
         <S.UserIdDisplay $isGroup={isGroup}>{userId}</S.UserIdDisplay>
       )}

--- a/src/components/studyProfileBox/imagebox/ProfileImageBox.style.ts
+++ b/src/components/studyProfileBox/imagebox/ProfileImageBox.style.ts
@@ -19,7 +19,7 @@ interface ProfileImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 
 export const ProfileImage = styled.img<ProfileImageProps>`
   border-radius: 50%;
-  width: 80%;
-  height: 80%;
+  width: 85%;
+  height: 85%;
   object-fit: cover;
 `;

--- a/src/components/studyProfileBox/imagebox/ProfileImageBox.style.ts
+++ b/src/components/studyProfileBox/imagebox/ProfileImageBox.style.ts
@@ -14,7 +14,7 @@ export const ProfileImageContainer = styled.div<{
 `;
 
 interface ProfileImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
-  isDefault: boolean;
+  isDefault?: boolean;
 }
 
 export const ProfileImage = styled.img<ProfileImageProps>`

--- a/src/components/studyProfileBox/imagebox/ProfileImageBox.tsx
+++ b/src/components/studyProfileBox/imagebox/ProfileImageBox.tsx
@@ -15,11 +15,10 @@ const ProfileImageBox: React.FC<ProfileImageBoxProps> = ({
   height,
 }) => {
   const imageSrc = src && src.trim() !== '' ? src : defaultImage;
-  const isDefault = imageSrc === defaultImage;
 
   return (
     <S.ProfileImageContainer width={width} height={height}>
-      <S.ProfileImage src={imageSrc} alt={alt} isDefault={isDefault} />
+      <S.ProfileImage src={imageSrc} alt={alt} />
     </S.ProfileImageContainer>
   );
 };

--- a/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
+++ b/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
@@ -100,32 +100,27 @@ const PrivateStudyRoom: React.FC<PrivateStudyRoomProps> = ({
   return (
     <S.PrivateStudyRoomStyle>
       <S.MainContentArea>
-        <S.StudyRoomHeaderWrap>
-          <Header title="개인 공부방" />
-          <S.StudyRoomWrap>
-            <StudyProfileBox
-              isGroup={false}
-              userId={userId}
-              initialCurrentTaskTime={currentTaskTime}
-              initialTotalStudyTime={totalStudyTime}
-              profileImage={profileImage}
-              profileImageWidth="400px"
-              profileImageHeight="400px"
-            />
-            <S.InstructionText>
-              우측 사이드바의 할 일을 선택하면 타이머가 시작됩니다.
-            </S.InstructionText>
-            <S.ButtonContainer>
-              <StartPauseButton
-                isActive={isActive}
-                onClick={handleStartPause}
-              />
-              <LeaveButton onClick={handleLeaveRoom} />
-            </S.ButtonContainer>
-          </S.StudyRoomWrap>
-        </S.StudyRoomHeaderWrap>
-        <RSidebar />
+        <Header title="개인 공부방" />
+        <S.StudyRoomWrap>
+          <StudyProfileBox
+            isGroup={false}
+            userId={userId}
+            initialCurrentTaskTime={currentTaskTime}
+            initialTotalStudyTime={totalStudyTime}
+            profileImage={profileImage}
+            profileImageWidth="400px"
+            profileImageHeight="400px"
+          />
+          <S.InstructionText>
+            우측 사이드바의 할 일을 선택하면 타이머가 시작됩니다.
+          </S.InstructionText>
+          <S.ButtonContainer>
+            <StartPauseButton isActive={isActive} onClick={handleStartPause} />
+            <LeaveButton onClick={handleLeaveRoom} />
+          </S.ButtonContainer>
+        </S.StudyRoomWrap>
       </S.MainContentArea>
+      <RSidebar />
     </S.PrivateStudyRoomStyle>
   );
 };

--- a/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
+++ b/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import LeaveButton from './components/button/LeaveButton';
 import * as S from './PrivateStudyRoomStyle';
 import Header from '@/components/header/Header';
+import RSidebar from '@/components/rsidebar/RSidebar';
 
 interface PrivateStudyRoomProps {
   userId?: string; // 사용자 ID
@@ -98,25 +99,33 @@ const PrivateStudyRoom: React.FC<PrivateStudyRoomProps> = ({
 
   return (
     <S.PrivateStudyRoomStyle>
-      <Header title="개인 공부방" />
-      <S.StudyRoomWrap>
-        <StudyProfileBox
-          isGroup={false}
-          userId={userId}
-          initialCurrentTaskTime={currentTaskTime}
-          initialTotalStudyTime={totalStudyTime}
-          profileImage={profileImage}
-          profileImageWidth="400px"
-          profileImageHeight="400px"
-        />
-        <S.InstructionText>
-          우측 사이드바의 할 일을 선택하면 타이머가 시작됩니다.
-        </S.InstructionText>
-        <S.ButtonContainer>
-          <StartPauseButton isActive={isActive} onClick={handleStartPause} />
-          <LeaveButton onClick={handleLeaveRoom} />
-        </S.ButtonContainer>
-      </S.StudyRoomWrap>
+      <S.MainContentArea>
+        <S.StudyRoomHeaderWrap>
+          <Header title="개인 공부방" />
+          <S.StudyRoomWrap>
+            <StudyProfileBox
+              isGroup={false}
+              userId={userId}
+              initialCurrentTaskTime={currentTaskTime}
+              initialTotalStudyTime={totalStudyTime}
+              profileImage={profileImage}
+              profileImageWidth="400px"
+              profileImageHeight="400px"
+            />
+            <S.InstructionText>
+              우측 사이드바의 할 일을 선택하면 타이머가 시작됩니다.
+            </S.InstructionText>
+            <S.ButtonContainer>
+              <StartPauseButton
+                isActive={isActive}
+                onClick={handleStartPause}
+              />
+              <LeaveButton onClick={handleLeaveRoom} />
+            </S.ButtonContainer>
+          </S.StudyRoomWrap>
+        </S.StudyRoomHeaderWrap>
+        <RSidebar />
+      </S.MainContentArea>
     </S.PrivateStudyRoomStyle>
   );
 };

--- a/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
+++ b/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
@@ -14,7 +14,8 @@ const PrivateStudyRoom: React.FC<PrivateStudyRoomProps> = ({
 }) => {
   const initialCurrentTaskTime = '00:00:00'; // 초기 현재 작업 시간
   const initialTotalStudyTime = '00:05:00'; // 초기 총 공부 시간
-  const profileImage = ''; // 프로필 이미지 URL
+  const profileImage =
+    'https://product.cdn.cevaws.com/var/storage/images/_aliases/reference/media/feliway-2017/images/kor-kr/1_gnetb-7sfmbx49emluey4a/6341829-1-kor-KR/1_gNETb-7SfMBX49EMLUeY4A.jpg'; // 프로필 이미지 URL
 
   const navigate = useNavigate();
   const [isActive, setIsActive] = useState(false);

--- a/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
+++ b/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
@@ -103,6 +103,8 @@ const PrivateStudyRoom: React.FC<PrivateStudyRoomProps> = ({
         initialCurrentTaskTime={currentTaskTime}
         initialTotalStudyTime={totalStudyTime}
         profileImage={profileImage}
+        profileImageWidth="400px"
+        profileImageHeight="400px"
       />
       <S.InstructionText>
         우측 사이드바의 할 일을 선택하면 타이머가 시작됩니다.

--- a/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
+++ b/src/pages/privateStudyRoom/PrivateStudyRoom.tsx
@@ -4,6 +4,7 @@ import StartPauseButton from './components/button/StartPauseButton';
 import { useNavigate } from 'react-router-dom';
 import LeaveButton from './components/button/LeaveButton';
 import * as S from './PrivateStudyRoomStyle';
+import Header from '@/components/header/Header';
 
 interface PrivateStudyRoomProps {
   userId?: string; // 사용자 ID
@@ -97,22 +98,25 @@ const PrivateStudyRoom: React.FC<PrivateStudyRoomProps> = ({
 
   return (
     <S.PrivateStudyRoomStyle>
-      <StudyProfileBox
-        isGroup={false}
-        userId={userId}
-        initialCurrentTaskTime={currentTaskTime}
-        initialTotalStudyTime={totalStudyTime}
-        profileImage={profileImage}
-        profileImageWidth="400px"
-        profileImageHeight="400px"
-      />
-      <S.InstructionText>
-        우측 사이드바의 할 일을 선택하면 타이머가 시작됩니다.
-      </S.InstructionText>
-      <S.ButtonContainer>
-        <StartPauseButton isActive={isActive} onClick={handleStartPause} />
-        <LeaveButton onClick={handleLeaveRoom} />
-      </S.ButtonContainer>
+      <Header title="개인 공부방" />
+      <S.StudyRoomWrap>
+        <StudyProfileBox
+          isGroup={false}
+          userId={userId}
+          initialCurrentTaskTime={currentTaskTime}
+          initialTotalStudyTime={totalStudyTime}
+          profileImage={profileImage}
+          profileImageWidth="400px"
+          profileImageHeight="400px"
+        />
+        <S.InstructionText>
+          우측 사이드바의 할 일을 선택하면 타이머가 시작됩니다.
+        </S.InstructionText>
+        <S.ButtonContainer>
+          <StartPauseButton isActive={isActive} onClick={handleStartPause} />
+          <LeaveButton onClick={handleLeaveRoom} />
+        </S.ButtonContainer>
+      </S.StudyRoomWrap>
     </S.PrivateStudyRoomStyle>
   );
 };

--- a/src/pages/privateStudyRoom/PrivateStudyRoomStyle.ts
+++ b/src/pages/privateStudyRoom/PrivateStudyRoomStyle.ts
@@ -11,11 +11,11 @@ export const PrivateStudyRoomStyle = styled.div`
 export const InstructionText = styled.div`
   text-align: center;
   margin: 20px 0;
-  font-size: 35px;
+  font-size: 30px;
 `;
 
 export const ButtonContainer = styled.div`
   display: flex;
   justify-content: space-between;
-  gap: 564px;
+  gap: 433px;
 `;

--- a/src/pages/privateStudyRoom/PrivateStudyRoomStyle.ts
+++ b/src/pages/privateStudyRoom/PrivateStudyRoomStyle.ts
@@ -2,18 +2,12 @@ import styled from 'styled-components';
 
 export const PrivateStudyRoomStyle = styled.div`
   display: flex;
-  flex-direction: column;
-  width: 100%;
+  justify-content: space-between;
+  width: 100vw;
   height: 100vh;
 `;
 
 export const MainContentArea = styled.div`
-  display: flex;
-  justify-content: space-between;
-  height: calc(100% - 80px);
-`;
-
-export const StudyRoomHeaderWrap = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -24,6 +18,7 @@ export const StudyRoomHeaderWrap = styled.div`
 export const StudyRoomWrap = styled.div`
   display: flex;
   flex-direction: column;
+  align-items: center;
   justify-content: space-between;
   height: 100vh;
   margin: 60px 0;

--- a/src/pages/privateStudyRoom/PrivateStudyRoomStyle.ts
+++ b/src/pages/privateStudyRoom/PrivateStudyRoomStyle.ts
@@ -4,14 +4,29 @@ export const PrivateStudyRoomStyle = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100vh;
+`;
+
+export const MainContentArea = styled.div`
+  display: flex;
+  justify-content: space-between;
+  height: calc(100% - 80px);
+`;
+
+export const StudyRoomHeaderWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  height: 100vh;
 `;
 
 export const StudyRoomWrap = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  flex: 1;
+  justify-content: space-between;
+  height: 100vh;
+  margin: 60px 0;
 `;
 
 export const InstructionText = styled.div`

--- a/src/pages/privateStudyRoom/PrivateStudyRoomStyle.ts
+++ b/src/pages/privateStudyRoom/PrivateStudyRoomStyle.ts
@@ -3,6 +3,12 @@ import styled from 'styled-components';
 export const PrivateStudyRoomStyle = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
+`;
+
+export const StudyRoomWrap = styled.div`
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   flex: 1;

--- a/src/pages/privateStudyRoom/components/button/LeaveButton.tsx
+++ b/src/pages/privateStudyRoom/components/button/LeaveButton.tsx
@@ -10,12 +10,13 @@ const LeaveButton: React.FC<LeaveButtonProps> = ({ onClick }) => {
   return (
     <SCreateButton
       label="나가기"
-      size="small"
+      width="160px"
+      height="56px"
       Icon={FiLogOut}
       onClick={onClick}
-      borderRadius="15px"
-      fontSize="40px"
-      iconSize="40px"
+      borderRadius="10px"
+      fontSize="24px"
+      iconSize="25px"
     />
   );
 };

--- a/src/pages/privateStudyRoom/components/button/StartPauseButton.tsx
+++ b/src/pages/privateStudyRoom/components/button/StartPauseButton.tsx
@@ -16,10 +16,11 @@ const StartPauseButton: React.FC<StartPauseButtonProps> = ({
       label={isActive ? '일시 정지' : '시작'}
       Icon={isActive ? FaPause : FaPlay}
       onClick={onClick}
-      size="small"
-      borderRadius="15px"
-      fontSize="40px"
-      iconSize="40px"
+      width="160px"
+      height="56px"
+      borderRadius="10px"
+      fontSize="24px"
+      iconSize="25px"
     />
   );
 };

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -7,6 +7,13 @@ const GlobalStyles = createGlobalStyle`
       box-sizing: border-box;
   }
 
+  html, body {
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+  }
+
   a{
         text-decoration: none;
         color: inherit;

--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -11,7 +11,7 @@ const GlobalStyles = createGlobalStyle`
     height: 100%;
     margin: 0;
     padding: 0;
-    overflow: hidden;
+    //overflow: hidden;
   }
 
   a{


### PR DESCRIPTION
## ✅ 작업 내용
1920 * 1080 -> 1280 * 832 에 맞춰서 공부방 페이지 UI 수정
우측 사이드 바는 크기 제외 하고 수정 안함.

개인 공부방 페이지일 경우
<img width="1470" alt="스크린샷 2024-09-30 오전 4 53 03" src="https://github.com/user-attachments/assets/45804a3a-681d-468f-ac52-58a84c8785aa">


그룹 공부방 페이지일 경우 - 스터디 프로필 박스
<img width="1470" alt="스크린샷 2024-09-29 오후 7 00 07" src="https://github.com/user-attachments/assets/1a4d3179-5320-448b-a9c4-20b248e63c87">

- [ ] 웹소켓이 연동 되면, 그룹 공부방 페이지에서 본인일 경우엔 선택된 할 일 공부시간과, 시간이 표시되도록 구현 하겠습니다.

## ✅ 리뷰 요청사항
Layout에 헤더 있는 상태로 하다가 포기하고 그냥 공부방 페이지 자체에 헤더 추가 했습니다.

## 📢 관련 이슈
- close #34 