### PR TITLE
[FEAT] 헤더에 사용자 프로필 이미지 표시 

### DIFF
--- a/src/components/header/Header.style.ts
+++ b/src/components/header/Header.style.ts
@@ -40,3 +40,11 @@ export const ButtonWrapper = styled.div`
   display: flex;
   gap: 10px;
 `;
+
+export const ProfileImg = styled.img`
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+  border: 1px solid lightgray;
+`;

--- a/src/components/header/Header.style.ts
+++ b/src/components/header/Header.style.ts
@@ -57,7 +57,7 @@ export const DropdownProfileImg = styled.img`
   border: 1px solid lightgray;
 `;
 
-export const DropDownWrapper = styled.div`
+export const DropDownWrapper = styled.div<{ isOpen: boolean }>`
   display: flex;
   flex-direction: column;
   position: absolute;
@@ -67,6 +67,11 @@ export const DropDownWrapper = styled.div`
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   background-color: white;
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  transform: translateY(${({ isOpen }) => (isOpen ? '0' : '-10px')});
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
 `;
 
 export const UserInfo = styled.div`

--- a/src/components/header/Header.style.ts
+++ b/src/components/header/Header.style.ts
@@ -10,6 +10,7 @@ export const HeaderContainer = styled.header<{ isStudyRoomPage?: boolean }>`
   justify-content: space-between;
   align-items: center;
   padding: 32px;
+  position: relative;
 `;
 
 export const HeaderTitle = styled.h1`
@@ -47,4 +48,51 @@ export const ProfileImg = styled.img`
   height: 32px;
   cursor: pointer;
   border: 1px solid lightgray;
+`;
+
+export const DropdownProfileImg = styled.img`
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  border: 1px solid lightgray;
+`;
+
+export const DropDownWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 70px;
+  right: 20px;
+  min-width: 240px;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  background-color: white;
+`;
+
+export const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 20px;
+  border-bottom: 1px solid lightgray;
+  width: 100%;
+`;
+
+export const DropdownText = styled.p`
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+export const DropdownItems = styled.div`
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 14px 20px;
+  color: #616161;
+
+  &:hover {
+    background-color: #f4f4f4;
+  }
 `;

--- a/src/components/header/Header.style.ts
+++ b/src/components/header/Header.style.ts
@@ -57,7 +57,7 @@ export const DropdownProfileImg = styled.img`
   border: 1px solid lightgray;
 `;
 
-export const DropDownWrapper = styled.div<{ isOpen: boolean }>`
+export const DropDownWrapper = styled.div<{ $isOpen: boolean }>`
   display: flex;
   flex-direction: column;
   position: absolute;
@@ -67,8 +67,8 @@ export const DropDownWrapper = styled.div<{ isOpen: boolean }>`
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
   background-color: white;
-  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
-  transform: translateY(${({ isOpen }) => (isOpen ? '0' : '-10px')});
+  opacity: ${({ $isOpen }) => ($isOpen ? 1 : 0)};
+  transform: translateY(${({ $isOpen }) => ($isOpen ? '0' : '-10px')});
   transition:
     opacity 0.3s ease,
     transform 0.3s ease;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -52,7 +52,7 @@ export default function Header({ title }: HeaderProps) {
     return user?.imageUrl ? (
       <S.ProfileImg src={user?.imageUrl} alt="Profile" />
     ) : (
-      <IoPersonCircle size={32} />
+      <IoPersonCircle size={32} color="gray" />
     );
   };
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,7 +3,12 @@ import { logout } from '@/apis/auth.api';
 import * as S from './Header.style';
 import { useAuthStore } from '@/stores/auth.store';
 import { toast } from 'react-toastify';
-import { IoPersonCircle } from 'react-icons/io5';
+import { useRef, useState } from 'react';
+import {
+  IoPersonCircle,
+  IoSettingsOutline,
+  IoLogOutOutline,
+} from 'react-icons/io5';
 
 interface HeaderProps {
   title: string;
@@ -12,6 +17,7 @@ interface HeaderProps {
 export default function Header({ title }: HeaderProps) {
   const navigate = useNavigate();
   const { accessToken, user, clearAuthData } = useAuthStore();
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleLogout = async () => {
     await logout();
@@ -20,6 +26,8 @@ export default function Header({ title }: HeaderProps) {
     navigate('/');
   };
 
+  const toggleDropdown = () => setIsOpen((prev) => !prev);
+
   const renderProfileImage = () => {
     return user?.imageUrl ? (
       <S.ProfileImg src={user?.imageUrl} alt="Profile" />
@@ -27,13 +35,36 @@ export default function Header({ title }: HeaderProps) {
       <IoPersonCircle size={32} />
     );
   };
+
+  const renderDropdown = () => {
+    return (
+      isOpen && (
+        <S.DropDownWrapper ref={dropdownRef}>
+          <S.UserInfo>
+            {renderProfileImage()}
+            <S.DropdownText>{user?.nickname} 님</S.DropdownText>
+          </S.UserInfo>
+          <S.DropdownItems onClick={() => navigate('/profile')}>
+            <IoSettingsOutline />
+            프로필 수정
+          </S.DropdownItems>
+          <S.DropdownItems onClick={handleLogout}>
+            <IoLogOutOutline />
+            로그아웃
+          </S.DropdownItems>
+        </S.DropDownWrapper>
+      )
+    );
+  };
+
   return (
     <S.HeaderContainer>
       <S.HeaderTitle>{title}</S.HeaderTitle>
       <S.ButtonWrapper>
         {accessToken ? (
           <>
-            {renderProfileImage()}
+            <div onClick={toggleDropdown}>{renderProfileImage()}</div>
+            {renderDropdown()}
           </>
         ) : (
           <>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -58,7 +58,7 @@ export default function Header({ title }: HeaderProps) {
 
   const renderDropdown = () => {
     return (
-      <S.DropDownWrapper ref={dropdownRef} isOpen={isOpen}>
+      <S.DropDownWrapper ref={dropdownRef} $isOpen={isOpen}>
         <S.UserInfo>
           {renderProfileImage()}
           <S.DropdownText>{user?.nickname} 님</S.DropdownText>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -58,22 +58,18 @@ export default function Header({ title }: HeaderProps) {
 
   const renderDropdown = () => {
     return (
-      isOpen && (
-        <S.DropDownWrapper ref={dropdownRef}>
-          <S.UserInfo>
-            {renderProfileImage()}
-            <S.DropdownText>{user?.nickname} 님</S.DropdownText>
-          </S.UserInfo>
-          <S.DropdownItems onClick={() => navigate('/profile')}>
-            <IoSettingsOutline />
-            프로필 수정
-          </S.DropdownItems>
-          <S.DropdownItems onClick={handleLogout}>
-            <IoLogOutOutline />
-            로그아웃
-          </S.DropdownItems>
-        </S.DropDownWrapper>
-      )
+      <S.DropDownWrapper ref={dropdownRef} isOpen={isOpen}>
+        <S.UserInfo>
+          {renderProfileImage()}
+          <S.DropdownText>{user?.nickname} 님</S.DropdownText>
+        </S.UserInfo>
+        <S.DropdownItems onClick={() => navigate('/profile')}>
+          <IoSettingsOutline /> 프로필 수정
+        </S.DropdownItems>
+        <S.DropdownItems onClick={handleLogout}>
+          <IoLogOutOutline /> 로그아웃
+        </S.DropdownItems>
+      </S.DropDownWrapper>
     );
   };
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,6 +3,7 @@ import { logout } from '@/apis/auth.api';
 import * as S from './Header.style';
 import { useAuthStore } from '@/stores/auth.store';
 import { toast } from 'react-toastify';
+import { IoPersonCircle } from 'react-icons/io5';
 
 interface HeaderProps {
   title: string;
@@ -10,7 +11,7 @@ interface HeaderProps {
 
 export default function Header({ title }: HeaderProps) {
   const navigate = useNavigate();
-  const { accessToken, clearAuthData } = useAuthStore();
+  const { accessToken, user, clearAuthData } = useAuthStore();
 
   const handleLogout = async () => {
     await logout();
@@ -19,14 +20,20 @@ export default function Header({ title }: HeaderProps) {
     navigate('/');
   };
 
+  const renderProfileImage = () => {
+    return user?.imageUrl ? (
+      <S.ProfileImg src={user?.imageUrl} alt="Profile" />
+    ) : (
+      <IoPersonCircle size={32} />
+    );
+  };
   return (
     <S.HeaderContainer>
       <S.HeaderTitle>{title}</S.HeaderTitle>
       <S.ButtonWrapper>
         {accessToken ? (
           <>
-            <S.Button onClick={handleLogout}>로그아웃</S.Button>
-            <S.Button onClick={() => navigate('/profile')}>프로필</S.Button>
+            {renderProfileImage()}
           </>
         ) : (
           <>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,7 +3,7 @@ import { logout } from '@/apis/auth.api';
 import * as S from './Header.style';
 import { useAuthStore } from '@/stores/auth.store';
 import { toast } from 'react-toastify';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   IoPersonCircle,
   IoSettingsOutline,
@@ -18,6 +18,26 @@ export default function Header({ title }: HeaderProps) {
   const navigate = useNavigate();
   const { accessToken, user, clearAuthData } = useAuthStore();
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const profileRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node) &&
+        profileRef.current &&
+        !profileRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
 
   const handleLogout = async () => {
     await logout();
@@ -63,7 +83,9 @@ export default function Header({ title }: HeaderProps) {
       <S.ButtonWrapper>
         {accessToken ? (
           <>
-            <div onClick={toggleDropdown}>{renderProfileImage()}</div>
+            <div ref={profileRef} onClick={toggleDropdown}>
+              {renderProfileImage()}
+            </div>
             {renderDropdown()}
           </>
         ) : (

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -23,18 +23,22 @@ interface AuthState {
 
 export const useAuthStore = create<AuthState>((set) => ({
   accessToken: Cookies.get('accessToken') || null,
-  user: null,
+  user: Cookies.get('user') ? JSON.parse(Cookies.get('user') as string) : null,
+
   setAuthData: (accessToken, user) => {
     set(() => ({ accessToken, user }));
-    if (accessToken) {
+    if (accessToken && user) {
       Cookies.set('accessToken', accessToken, { expires: 0.0104 });
+      Cookies.set('user', JSON.stringify(user), { expires: 1 });
     } else {
       Cookies.remove('accessToken');
+      Cookies.remove('user');
     }
   },
 
   clearAuthData: () => {
     set({ accessToken: null, user: null });
     Cookies.remove('accessToken');
+    Cookies.remove('user');
   },
 }));

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -8,7 +8,6 @@ interface AuthState {
     nickname: string;
     imageUrl?: string;
     introduction?: string;
-    dDay?: string;
   } | null;
   setAuthData: (
     accessToken: string,
@@ -17,7 +16,6 @@ interface AuthState {
       nickname: string;
       imageUrl?: string;
       introduction?: string;
-      dDay?: string;
     } | null
   ) => void;
   clearAuthData: () => void;


### PR DESCRIPTION
## ✅ 작업 내용
사용자 정보를 쿠키에 저장하여 항상 가지고 있도록 수정했습니다!

헤더에 사용자 프로필 이미지를 보여주고, **드롭다운** 기능을 추가하였습니다.
프로필 수정 페이지로 이동, 로그아웃 버튼이 있습니다. 
드롭다운 외부 클릭 시에는 닫기도록 구현 했습니다.

<img width="267" alt="스크린샷 2024-10-09 오후 6 00 52" src="https://github.com/user-attachments/assets/c32761e9-a9b9-4de1-8872-3fa7eff82524">
<img width="263" alt="스크린샷 2024-10-09 오후 6 06 17" src="https://github.com/user-attachments/assets/2128d1fb-e3c4-45fa-9fe4-167e97943af4">


## ✅ 리뷰 요청사항
사용자 정보 정확히 불러와지는지, 드롭다운 기능 제대로 작동하는지 확인 부탁드립니다!

## 📢 관련 이슈
- close #55 