### PR TITLE
[FIX] 비로그인 상태 처리

### DIFF
--- a/src/apis/axiosInstance.api.ts
+++ b/src/apis/axiosInstance.api.ts
@@ -18,6 +18,15 @@ axiosInstance.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    const { accessToken } = useAuthStore.getState();
+
+    if (!accessToken) {
+      alert('로그인이 필요한 서비스입니다.');
+
+      window.location.href = `${import.meta.env.VITE_REACT_APP_URL}/login`;
+      return Promise.reject(error);
+    }
+
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
 

--- a/src/components/header/Header.style.ts
+++ b/src/components/header/Header.style.ts
@@ -72,6 +72,7 @@ export const DropDownWrapper = styled.div<{ $isOpen: boolean }>`
   transition:
     opacity 0.3s ease,
     transform 0.3s ease;
+  z-index: 100;
 `;
 
 export const UserInfo = styled.div`

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -28,7 +28,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   setAuthData: (accessToken, user) => {
     set(() => ({ accessToken, user }));
     if (accessToken && user) {
-      Cookies.set('accessToken', accessToken, { expires: 0.0104 });
+      Cookies.set('accessToken', accessToken, { expires: 1 });
       Cookies.set('user', JSON.stringify(user), { expires: 1 });
     } else {
       Cookies.remove('accessToken');


### PR DESCRIPTION
## ✅ 작업 내용
비로그인 상태에서 토큰이 필요한 api 실행 시 refresh 무한 요청되는 오류 해결했습니다.
alert 창 띄우고 로그인 페이지도 이동하도록 했습니다.

## ✅ 리뷰 요청사항
다른 상황에서도 문제가 발생하진 않는지 확인 부탁드려요! 