### PR TITLE
[FIX] 공지사항 style 수정

### DIFF
--- a/src/pages/multiStudyRoom/component/StudyRoomNotice.style.ts
+++ b/src/pages/multiStudyRoom/component/StudyRoomNotice.style.ts
@@ -3,16 +3,17 @@ import styled from 'styled-components';
 export const StudyRoomNoticeStyle = styled.div`
   display: flex;
   position: absolute;
-  box-sizing: border-box;
   background-color: #ffdada;
+  width: 100%;
   padding: 24px;
   top: 80px;
-  z-index: 1000;
+  z-index: 15;
 `;
 
 export const NoticeDivOpen = styled.div`
   display: flex;
   flex-direction: row;
+  width: 100%;
   gap: 10px;
   left: 0;
 `;
@@ -30,7 +31,6 @@ export const OpenText = styled.div`
   height: auto;
   white-space: normal;
   font-size: 1.2rem;
-  line-height: 1.5;
 `;
 
 export const CloseText = styled.div`

--- a/src/pages/multiStudyRoom/multiStudyRoomContent/MultiStudyRoomContent.style.ts
+++ b/src/pages/multiStudyRoom/multiStudyRoomContent/MultiStudyRoomContent.style.ts
@@ -1,6 +1,4 @@
-import { scrollMixin } from '@/styles/mixins';
 import styled from 'styled-components';
-
 
 export const MultiStudyRoomContentStyle = styled.div`
   display: flex;
@@ -12,6 +10,7 @@ export const MultiStudyRoomContentStyle = styled.div`
 
 export const MainContentArea = styled.div`
   display: flex;
+  position: relative;
   flex-direction: column;
   align-items: center;
   flex: 1;


### PR DESCRIPTION
## ✅ 작업 내용
공지사항 글씨 갯수가 작을 시 범위 줄어드는거 해결
- 해결 전
<img width="681" alt="스크린샷 2024-10-17 오후 2 43 59" src="https://github.com/user-attachments/assets/729f0647-0b41-4484-bb8c-ca546e8fdad0">

- 해결 후
<img width="678" alt="스크린샷 2024-10-17 오후 2 44 36" src="https://github.com/user-attachments/assets/1d511bcd-bfa7-40a4-aa39-1c921a12a8fa">

- 공지 열었을 경우
<img width="680" alt="스크린샷 2024-10-17 오후 2 45 56" src="https://github.com/user-attachments/assets/1bc01b6f-ad5c-4e12-8181-18aaf4fa73be">

- 프로필 버튼도 눌렀을 경우
<img width="680" alt="스크린샷 2024-10-17 오후 2 45 34" src="https://github.com/user-attachments/assets/5e05567c-3cde-4e3f-828b-8a8100e9e343">

## ✅ 리뷰 요청사항

## 📢 관련 이슈
- close #84 